### PR TITLE
Fix lost of the last iteration in cycle

### DIFF
--- a/server/borders_api.py
+++ b/server/borders_api.py
@@ -793,7 +793,7 @@ def import_osm():
 		polygons = []
 		for way in outer:
 			rings = [way_to_wkt(nodes, way['nodes'])]
-			for i in range(len(inner)-1, 0, -1):
+			for i in range(len(inner)-1, -1, -1):
 				if bbox_contains(way['bbox'], inner[i]['bbox']):
 					rings.append(way_to_wkt(nodes, inner[i]['nodes']))
 					del inner[i]


### PR DESCRIPTION
Because of underiteration, a polygon may loose one of its inner rings during import. In particular, a polygon with one inner ring looses that ring and is not highlighted as having holes in the web-interface. The PR cures this.