### PR TITLE
Forbid joining a region with itself

### DIFF
--- a/server/borders_api.py
+++ b/server/borders_api.py
@@ -228,6 +228,8 @@ def join_borders():
 		abort(405)
 	name = request.args.get('name').encode('utf-8')
 	name2 = request.args.get('name2').encode('utf-8')
+	if name == name2:
+		return jsonify(status='cannot join region with itself')
 	cur = g.conn.cursor()
 	cur.execute('update {table} set geom = ST_Union(geom, b2.g), count_k = -1 from (select geom as g from {table} where name = %s) as b2 where name = %s;'.format(table=config.TABLE), (name2, name))
 	cur.execute('delete from {} where name = %s;'.format(config.TABLE), (name2,))

--- a/www/borders.js
+++ b/www/borders.js
@@ -570,7 +570,7 @@ function bJoin() {
 
 // called from selectLayer() when joinSelected is not null
 function bJoinSelect(layer) {
-	if( 'id' in layer && layer.id in borders ) {
+	if( 'id' in layer && layer.id in borders && layer.id != joinSelected ) {
 		joinAnother = layer.id;
 		$('#j_name2').text(joinAnother);
 		$('#j_do').css('display', 'block');


### PR DESCRIPTION
Now, the same region can be selected for join operation, resulting in nasty side effect of deleting it from database. The PR forbids selection of the same region for joining at frontend, and makes a check at backend.